### PR TITLE
feat: HTTP 쿼리 파라미터 파싱 및 메모리 관리 기능 구현

### DIFF
--- a/src/http.h
+++ b/src/http.h
@@ -53,8 +53,8 @@ struct http_headers parse_http_headers(char* headers_string);
 // 쿼리 파라미터
 struct http_query_parameter* insert_qurey_parameter(char* key, char* value);
 
-struct http_qurey_parameter* find_qurey_parameter(char* key);
-struct http_qurey_parameters parse_qurey_parameters(char* parameters_string);
+struct http_query_parameter* find_qurey_parameter(char* key);
+struct http_query_parameters parse_qurey_parameters(char* parameters_string);
 void free_query_parameters(struct http_query_parameters* query_parameters);
 
 

--- a/src/http.h
+++ b/src/http.h
@@ -50,10 +50,12 @@ struct http_header* insert_header(char* key, char* value);
 struct http_header* find_header(char* key);
 struct http_headers parse_http_headers(char* headers_string);
 
-struct http_header* insert_qurey_parameter(char* key, char* value);
+// 쿼리 파라미터
+struct http_query_parameter* insert_qurey_parameter(char* key, char* value);
 
 struct http_qurey_parameter* find_qurey_parameter(char* key);
 struct http_qurey_parameters parse_qurey_parameters(char* parameters_string);
+void free_query_parameters(struct http_query_parameters* query_parameters);
 
 
 char* http_response_stringfy(struct http_response http_response);

--- a/src/http.h
+++ b/src/http.h
@@ -51,10 +51,13 @@ struct http_header* find_header(char* key);
 struct http_headers parse_http_headers(char* headers_string);
 
 // 쿼리 파라미터
+struct http_query_parameter parse_http_query_parameter(
+	char		*key,
+	char		*value
+);
 struct http_query_parameter* insert_qurey_parameter(char* key, char* value);
-
-struct http_query_parameter* find_qurey_parameter(char* key);
-struct http_query_parameters parse_qurey_parameters(char* parameters_string);
+struct http_query_parameter* find_query_parameter(char* key);
+struct http_query_parameters parse_query_parameters(char* parameters_string);
 void free_query_parameters(struct http_query_parameters* query_parameters);
 
 

--- a/src/main.c
+++ b/src/main.c
@@ -44,6 +44,18 @@ struct http_query_parameters parse_qurey_parameters(char* parameters_string){
 }
 
 /**
+ * @brief Frees the memory allocated for an http_query_parameters structure.
+ * 
+ * @param query_parameters The http_query_parameters structure to free.
+ */
+void free_query_parameters(struct http_query_parameters* query_parameters){
+    for (int i = 0; i < query_parameters->size; i++) {
+        free(query_parameters->parameters[i]);
+    }
+    free(query_parameters->parameters);
+}
+
+/**
  * @brief Build Test 용
  * 
  * @return int 프로그램 종료 상태

--- a/src/main.c
+++ b/src/main.c
@@ -65,17 +65,20 @@ struct http_query_parameters parse_query_parameters(char* parameters_string){
     query_parameters.parameters = 
         (struct http_query_parameter**)malloc(sizeof(struct http_query_parameter*) * 10);
     
-    char* token = strtok(parameters_string, "&");
+    char *save_ptr1;
+    char *save_ptr2;
+
+    char* token = strtok_r(parameters_string, "&",&save_ptr1);
     
     while(token != NULL){
-        char* key = strtok(token, "=");
-        char* value = strtok(NULL, "=");
+        char* key = strtok_r(token, "=", &save_ptr2);
+        char* value = strtok_r(NULL, "=", &save_ptr2);
 
         struct http_query_parameter* query_parameter = 
             insert_query_parameter(key, value);
         
         query_parameters.parameters[query_parameters.size++] = query_parameter;
-        token = strtok(NULL, "&");
+        token = strtok_r(NULL, "&", &save_ptr1);
     }
     return query_parameters;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -65,7 +65,9 @@ struct http_query_parameters parse_query_parameters(char* parameters_string){
     query_parameters.parameters = 
         (struct http_query_parameter**)malloc(sizeof(struct http_query_parameter*) * 10);
     
+    /* '&' 구분자 처리 */
     char *save_ptr1;
+    /* '=' 구분자 처리 */
     char *save_ptr2;
 
     char* token = strtok_r(parameters_string, "&",&save_ptr1);

--- a/src/main.c
+++ b/src/main.c
@@ -19,9 +19,35 @@ struct http_query_parameter parse_http_query_parameter(char *key, char *value){
     
     return query_parameter;
 }
+
+/**
+ * @brief Allocates memory and stores a single HTTP query parameter.
  * 
- * @warning The caller is responsible for freeing the allocated memory
- * @note The maximum number of parameters is limited to 10
+ * This function parses a key and value into a struct http_query_parameter,
+ * allocates memory for it, and returns a pointer to the allocated memory.
+ * 
+ * @param key The key of the query parameter.
+ * @param value The value of the query parameter.
+ * @return struct http_query_parameter* Pointer to the allocated query parameter.
+ */
+struct http_query_parameter* insert_query_parameter(char* key, char* value){
+
+    struct http_query_parameter parsed = parse_http_query_parameter(key, value);
+
+    struct http_query_parameter* query_parameter = 
+        (struct http_query_parameter*)malloc(sizeof(struct http_query_parameter));
+    
+    if (!query_parameter) {
+        return NULL;
+    }
+
+    query_parameter->key = parsed.key;
+    query_parameter->value = parsed.value;
+    
+    return query_parameter;
+}
+
+
  */
 struct http_query_parameters parse_qurey_parameters(char* parameters_string){
     

--- a/src/main.c
+++ b/src/main.c
@@ -81,15 +81,38 @@ struct http_query_parameters parse_query_parameters(char* parameters_string){
 }
 
 /**
- * @brief Frees the memory allocated for an http_query_parameters structure.
+ * @brief Frees memory allocated for query parameters.
  * 
- * @param query_parameters The http_query_parameters structure to free.
+ * This function frees the memory allocated for each query parameter's key and value,
+ * as well as the memory allocated for the struct http_query_parameter itself. It also
+ * frees the memory allocated for the array of query parameters and resets the size.
+ * 
+ * @param query_parameters Pointer to the struct http_query_parameters to be freed.
  */
 void free_query_parameters(struct http_query_parameters* query_parameters){
-    for (int i = 0; i < query_parameters->size; i++) {
+    
+    if (!query_parameters) {
+        return;
+    }
+
+    if (query_parameters->parameters){
+        for (int i = 0; i < query_parameters->size; i++){
+            if (query_parameters->parameters[i]) {
+
+                // key와 value 메모리 해제
+                free(query_parameters->parameters[i]->key);
+                free(query_parameters->parameters[i]->value);
+                
+                // parameter 구조체 자체 해제
         free(query_parameters->parameters[i]);
     }
+        }
+
     free(query_parameters->parameters);
+        query_parameters->parameters = NULL;
+    }
+    
+    query_parameters->size = 0;
 }
 
 /**

--- a/src/main.c
+++ b/src/main.c
@@ -104,11 +104,11 @@ void free_query_parameters(struct http_query_parameters* query_parameters){
                 free(query_parameters->parameters[i]->value);
                 
                 // parameter 구조체 자체 해제
-        free(query_parameters->parameters[i]);
-    }
+                free(query_parameters->parameters[i]);
+            }
         }
 
-    free(query_parameters->parameters);
+        free(query_parameters->parameters);
         query_parameters->parameters = NULL;
     }
     

--- a/src/main.c
+++ b/src/main.c
@@ -4,11 +4,11 @@
  * @brief Parses a single HTTP query parameter.
  * 
  * This function takes a key and a value as input and returns a 
- * struct http_query_parameter containing the parsed key and value.
+ * struct http_query_parameter containing the parsedParam key and value.
  * 
  * @param key The key of the query parameter.
  * @param value The value of the query parameter.
- * @return struct http_query_parameter The parsed query parameter.
+ * @return struct http_query_parameter The parsedParam query parameter.
  */
 struct http_query_parameter parse_http_query_parameter(char *key, char *value){
 
@@ -32,7 +32,7 @@ struct http_query_parameter parse_http_query_parameter(char *key, char *value){
  */
 struct http_query_parameter* insert_query_parameter(char* key, char* value){
 
-    struct http_query_parameter parsed = parse_http_query_parameter(key, value);
+    struct http_query_parameter parsedParam = parse_http_query_parameter(key, value);
 
     struct http_query_parameter* query_parameter = 
         (struct http_query_parameter*)malloc(sizeof(struct http_query_parameter));
@@ -41,8 +41,8 @@ struct http_query_parameter* insert_query_parameter(char* key, char* value){
         return NULL;
     }
 
-    query_parameter->key = parsed.key;
-    query_parameter->value = parsed.value;
+    query_parameter->key = parsedParam.key;
+    query_parameter->value = parsedParam.value;
     
     return query_parameter;
 }
@@ -55,8 +55,8 @@ struct http_query_parameter* insert_query_parameter(char* key, char* value){
  * and stores them in a struct http_query_parameters. It allocates memory for 
  * each query parameter and returns the struct containing all parameters.
  * 
- * @param parameters_string The query string to be parsed.
- * @return struct http_query_parameters The parsed query parameters.
+ * @param parameters_string The query string to be parsedParam.
+ * @return struct http_query_parameters The parsedParam query parameters.
  */
 struct http_query_parameters parse_query_parameters(char* parameters_string){
     

--- a/src/main.c
+++ b/src/main.c
@@ -1,24 +1,24 @@
 #include "http.h"
 
-struct http_query_parameter* insert_qurey_parameter(char* key, char* value){
-    
-}
-
 /**
- * @brief Parses URL query parameters string into a structured format
- * @param parameters_string The raw query parameter string (format: "key1=value1&key2=value2...")
- * @return struct http_query_parameters A structure containing all parsed query parameters
+ * @brief Parses a single HTTP query parameter.
  * 
- * @details This function takes a URL query parameter string and breaks it down into individual
- * key-value pairs. The string should be in the format "key1=value1&key2=value2&...".
- * Each pair is separated by '&' and each key and value within a pair is separated by '='.
+ * This function takes a key and a value as input and returns a 
+ * struct http_query_parameter containing the parsed key and value.
  * 
- * The function:
- * - Allocates memory for up to 10 query parameters
- * - Splits the string on '&' characters to separate parameters
- * - For each parameter, splits on '=' to separate key and value
- * - Creates a new query_parameter structure for each pair
- * - Stores all parameters in the returned http_query_parameters structure
+ * @param key The key of the query parameter.
+ * @param value The value of the query parameter.
+ * @return struct http_query_parameter The parsed query parameter.
+ */
+struct http_query_parameter parse_http_query_parameter(char *key, char *value){
+
+    struct http_query_parameter query_parameter;
+    
+    query_parameter.key = key;
+    query_parameter.value = value;
+    
+    return query_parameter;
+}
  * 
  * @warning The caller is responsible for freeing the allocated memory
  * @note The maximum number of parameters is limited to 10

--- a/src/main.c
+++ b/src/main.c
@@ -41,8 +41,8 @@ struct http_query_parameter* insert_query_parameter(char* key, char* value){
         return NULL;
     }
 
-    query_parameter->key = parsedParam.key;
-    query_parameter->value = parsedParam.value;
+    query_parameter->key = strdup(parsedParam.key);
+    query_parameter->value = strdup(parsedParam.value);
     
     return query_parameter;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -1,7 +1,52 @@
 #include "http.h"
 
+struct http_query_parameter* insert_qurey_parameter(char* key, char* value){
+    
+}
+
+/**
+ * @brief Parses URL query parameters string into a structured format
+ * @param parameters_string The raw query parameter string (format: "key1=value1&key2=value2...")
+ * @return struct http_query_parameters A structure containing all parsed query parameters
+ * 
+ * @details This function takes a URL query parameter string and breaks it down into individual
+ * key-value pairs. The string should be in the format "key1=value1&key2=value2&...".
+ * Each pair is separated by '&' and each key and value within a pair is separated by '='.
+ * 
+ * The function:
+ * - Allocates memory for up to 10 query parameters
+ * - Splits the string on '&' characters to separate parameters
+ * - For each parameter, splits on '=' to separate key and value
+ * - Creates a new query_parameter structure for each pair
+ * - Stores all parameters in the returned http_query_parameters structure
+ * 
+ * @warning The caller is responsible for freeing the allocated memory
+ * @note The maximum number of parameters is limited to 10
+ */
+struct http_query_parameters parse_qurey_parameters(char* parameters_string){
+    
+    struct http_query_parameters query_parameters;
+    query_parameters.size = 0;
+    query_parameters.parameters = (struct http_query_parameter**)malloc(sizeof(struct http_query_parameter*) * 10);
+    
+    char* token = strtok(parameters_string, "&");
+    
+    while(token != NULL){
+        char* key = strtok(token, "=");
+        char* value = strtok(NULL, "=");
+
+        struct http_query_parameter* query_parameter = insert_qurey_parameter(key, value);
+        
+        query_parameters.parameters[query_parameters.size++] = query_parameter;
+        token = strtok(NULL, "&");
+    }
+    return query_parameters;
+}
+
 /**
  * @brief Build Test 용
+ * 
+ * @return int 프로그램 종료 상태
  */
 int main() {
     printf("Hello World\n");

--- a/src/main.c
+++ b/src/main.c
@@ -48,12 +48,22 @@ struct http_query_parameter* insert_query_parameter(char* key, char* value){
 }
 
 
+/**
+ * @brief Parses an entire query string into multiple query parameters.
+ * 
+ * This function takes a query string, parses it into individual key-value pairs,
+ * and stores them in a struct http_query_parameters. It allocates memory for 
+ * each query parameter and returns the struct containing all parameters.
+ * 
+ * @param parameters_string The query string to be parsed.
+ * @return struct http_query_parameters The parsed query parameters.
  */
-struct http_query_parameters parse_qurey_parameters(char* parameters_string){
+struct http_query_parameters parse_query_parameters(char* parameters_string){
     
     struct http_query_parameters query_parameters;
     query_parameters.size = 0;
-    query_parameters.parameters = (struct http_query_parameter**)malloc(sizeof(struct http_query_parameter*) * 10);
+    query_parameters.parameters = 
+        (struct http_query_parameter**)malloc(sizeof(struct http_query_parameter*) * 10);
     
     char* token = strtok(parameters_string, "&");
     
@@ -61,7 +71,8 @@ struct http_query_parameters parse_qurey_parameters(char* parameters_string){
         char* key = strtok(token, "=");
         char* value = strtok(NULL, "=");
 
-        struct http_query_parameter* query_parameter = insert_qurey_parameter(key, value);
+        struct http_query_parameter* query_parameter = 
+            insert_query_parameter(key, value);
         
         query_parameters.parameters[query_parameters.size++] = query_parameter;
         token = strtok(NULL, "&");


### PR DESCRIPTION
## 구현 내용
HTTP 쿼리 문자열을 파싱하고 메모리를 관리하는 기능을 구현했습니다:

- 단일 쿼리 파라미터 파싱 함수 구현 (`parse_http_query_parameter`)
- 쿼리 파라미터 메모리 할당 및 저장 함수 구현 (`insert_query_parameter`) 
- 전체 쿼리 문자열 파싱 기능 구현 (`parse_query_parameters`)
- 할당된 메모리 해제 함수 구현 (`free_query_parameters`)

## 주요 기능
- 쿼리 문자열을 key-value 쌍으로 파싱
- 동적 메모리 할당을 통한 쿼리 파라미터 관리
- 메모리 누수 방지를 위한 적절한 해제 처리
- 최대 10개의 쿼리 파라미터 지원

## 테스트
- 기본적인 빌드 테스트 완료 (`main` 함수 구현)
- 메모리 누수 확인 완료

## 관련 이슈
#22 , #19 , #11 , #10, #27

## 기타
- 추후 쿼리 파라미터 개수 제한을 동적으로 조정할 수 있도록 개선 필요
- `strtok()` -> `strtok_r()` 으로 thread safe 하게 변경