### PR TITLE
chore: Update makefile to organize generated files (#38)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,26 +10,30 @@ OUT_DIR = ./out
 SRCS = $(notdir $(wildcard $(SRC_DIR)/*.c))
 OBJS = $(SRCS:.c=.o)
 
-all: $(OUT_DIR) $(shared) $(bin) arrange
+all: $(OUT_DIR) $(shared) arrange
+
+binary: $(OUT_DIR) $(bin) arrange
 
 $(OUT_DIR):
 	mkdir -p $@
 	mkdir -p $@/libs
 	mkdir -p $@/include
+	mkdir -p $@/include/webserver
 
 arrange:
-	mv *.o *.d $(OUT_DIR)	
-	cp $(bin) $(OUT_DIR)
-	cp $(SRC_DIR)/*.h $(OUT_DIR)/include
+	mv *.o *.d $(OUT_DIR)
 
 %.o: $(SRC_DIR)/%.c
 	$(CC) $(CFLAGS) -c $< -o $@ -MD $(LDFLAGS)
 
 $(shared): $(OBJS)
-	$(CC) -shared $(CFLAGS) -o $(OUT_DIR)/libs/$@ $< $(LDFLAGS)
+	$(CC) -shared $(CFLAGS) -o $(OUT_DIR)/libs/$@ $(OBJS) $(LDFLAGS)
+	cp $(SRC_DIR)/*.h $(OUT_DIR)/include/webserver
 
 $(bin): $(OBJS)
 	$(CC) $(CFLAGS) $(OBJS) -o $@ $(LDFLAGS)
+
+
 
 
 
@@ -37,6 +41,5 @@ $(bin): $(OBJS)
 clean:
 	rm -f $(bin) *.o *.d
 	rm out -r
-
 
 -include $(OBJS:.o=.d)

--- a/Makefile
+++ b/Makefile
@@ -2,23 +2,41 @@ CFLAGS = -Wall -g -std=c2x
 LDFLAGS = -I. -L. -lpthread
 
 bin = prog
+shared = webserver.so
 
 SRC_DIR = ./src
+OUT_DIR = ./out
 
 SRCS = $(notdir $(wildcard $(SRC_DIR)/*.c))
 OBJS = $(SRCS:.c=.o)
 
-all: $(bin)
+all: $(OUT_DIR) $(shared) $(bin) arrange
+
+$(OUT_DIR):
+	mkdir -p $@
+	mkdir -p $@/libs
+	mkdir -p $@/include
+
+arrange:
+	mv *.o *.d $(OUT_DIR)	
+	cp $(bin) $(OUT_DIR)
+	cp $(SRC_DIR)/*.h $(OUT_DIR)/include
 
 %.o: $(SRC_DIR)/%.c
 	$(CC) $(CFLAGS) -c $< -o $@ -MD $(LDFLAGS)
 
+$(shared): $(OBJS)
+	$(CC) -shared $(CFLAGS) -o $(OUT_DIR)/libs/$@ $< $(LDFLAGS)
+
 $(bin): $(OBJS)
 	$(CC) $(CFLAGS) $(OBJS) -o $@ $(LDFLAGS)
+
+
 
 .PHONY: clean all
 clean:
 	rm -f $(bin) *.o *.d
+	rm out -r
 
 
 -include $(OBJS:.o=.d)

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CFLAGS = -Wall -g -std=c2x
 LDFLAGS = -I. -L. -lpthread
 
 bin = prog
-shared = webserver.so
+shared = libwebserver.so
 
 SRC_DIR = ./src
 OUT_DIR = ./out


### PR DESCRIPTION
@xharpenParksuhyeon 
수정하다 보니까 https://github.com/GDB-Online-Clone/http_web_server_c/pull/61 PR에도 Makefile 수정이 발생했어요.
`CFLAGS = -Wall -std=c2x -g -DDEBUG` 
`bin = prog # exists only for debugging`
병합 순서를 어떻게 하실 지 모르겠지만, https://github.com/GDB-Online-Clone/http_web_server_c/pull/61 PR에서는 위의 두 라인을 가져가주시면 됩니다.

## 수정 사항
- 실행 파일을 빌드하기 위한 make 규칙 작성: `make binary`
- 이제 `make all` 은 실행 파일을 빌드하지 않고, 오직 라이브러리만 빌드합니다.
- `make` 시 `./out` 디렉토리를 생성하고 빌드시 생성된 `.d` `.o` 파일을 해당 디렉토리로 이동시킴
- `make` 시 shared library 빌드를 위해 `webserver.so` 와 헤더 파일을 담는 `include` 디렉토리 생성
- 요약하면 아래와 같은 디렉토리 구조를 가짐
```bash
out
├── include
│   └── webserver
│       ├── http.h
│       └── utility.h
├── libs
│   └── libwebserver.so
├── main.d
├── main.o
├── utility.d
└── utility.o
```
- `make clean` 동작또한 위의 디렉토리를 삭제하도록 수정

## 수정 후 기대 효과
- 빌드 결과를 확인하기 용이해지며, 라이브러리를 쉽게 배포할 수 있음