### PR TITLE
Fix Makefile Issues: Shared Library Build Errors and .so File Naming Fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,26 +10,30 @@ OUT_DIR = ./out
 SRCS = $(notdir $(wildcard $(SRC_DIR)/*.c))
 OBJS = $(SRCS:.c=.o)
 
-all: $(OUT_DIR) $(shared) $(bin) arrange
+all: $(OUT_DIR) $(shared) arrange
+
+binary: $(OUT_DIR) $(bin) arrange
 
 $(OUT_DIR):
 	mkdir -p $@
 	mkdir -p $@/libs
 	mkdir -p $@/include
+	mkdir -p $@/include/webserver
 
 arrange:
-	mv *.o *.d $(OUT_DIR)	
-	cp $(bin) $(OUT_DIR)
-	cp $(SRC_DIR)/*.h $(OUT_DIR)/include
+	mv *.o *.d $(OUT_DIR)
 
 %.o: $(SRC_DIR)/%.c
 	$(CC) $(CFLAGS) -c $< -o $@ -MD $(LDFLAGS)
 
 $(shared): $(OBJS)
-	$(CC) -shared $(CFLAGS) -o $(OUT_DIR)/libs/$@ $< $(LDFLAGS)
+	$(CC) -shared $(CFLAGS) -o $(OUT_DIR)/libs/$@ $(OBJS) $(LDFLAGS)
+	cp $(SRC_DIR)/*.h $(OUT_DIR)/include/webserver
 
 $(bin): $(OBJS)
 	$(CC) $(CFLAGS) $(OBJS) -o $@ $(LDFLAGS)
+
+
 
 
 
@@ -37,6 +41,5 @@ $(bin): $(OBJS)
 clean:
 	rm -f $(bin) *.o *.d
 	rm out -r
-
 
 -include $(OBJS:.o=.d)

--- a/Makefile
+++ b/Makefile
@@ -2,23 +2,41 @@ CFLAGS = -Wall -g -std=c2x
 LDFLAGS = -I. -L. -lpthread
 
 bin = prog
+shared = webserver.so
 
 SRC_DIR = ./src
+OUT_DIR = ./out
 
 SRCS = $(notdir $(wildcard $(SRC_DIR)/*.c))
 OBJS = $(SRCS:.c=.o)
 
-all: $(bin)
+all: $(OUT_DIR) $(shared) $(bin) arrange
+
+$(OUT_DIR):
+	mkdir -p $@
+	mkdir -p $@/libs
+	mkdir -p $@/include
+
+arrange:
+	mv *.o *.d $(OUT_DIR)	
+	cp $(bin) $(OUT_DIR)
+	cp $(SRC_DIR)/*.h $(OUT_DIR)/include
 
 %.o: $(SRC_DIR)/%.c
 	$(CC) $(CFLAGS) -c $< -o $@ -MD $(LDFLAGS)
 
+$(shared): $(OBJS)
+	$(CC) -shared $(CFLAGS) -o $(OUT_DIR)/libs/$@ $< $(LDFLAGS)
+
 $(bin): $(OBJS)
 	$(CC) $(CFLAGS) $(OBJS) -o $@ $(LDFLAGS)
+
+
 
 .PHONY: clean all
 clean:
 	rm -f $(bin) *.o *.d
+	rm out -r
 
 
 -include $(OBJS:.o=.d)

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CFLAGS = -Wall -g -std=c2x
 LDFLAGS = -I. -L. -lpthread
 
 bin = prog
-shared = webserver.so
+shared = libwebserver.so
 
 SRC_DIR = ./src
 OUT_DIR = ./out

--- a/src/http.h
+++ b/src/http.h
@@ -22,8 +22,6 @@
 enum http_status_code;
 enum http_method;
 
-// GET /index.html HTTP/1.1\r\nHost: localhost:4221\r\nUser-Agent: curl/7.64.1\r\nAccept: */*\r\n\r\n
-
 struct route;
 struct http_header;
 struct http_headers;


### PR DESCRIPTION
### Pull Request 제목
"Makefile 수정: 공유 라이브러리 빌드 오류 및 `.so` 파일 명명 규칙 수정"

### Pull Request 설명
이 Pull Request는 `Makefile`의 여러 문제를 해결하여 빌드 프로세스를 개선하고 특정 오류를 수정합니다. 주요 변경 사항은 다음과 같습니다:

1. **생성 파일 정리**:
   - `Makefile`을 업데이트하여 생성된 파일을 효과적으로 관리하고 정리했습니다.
   - 이를 통해 빌드 환경을 더 깔끔하게 유지하고 불필요한 파일이 쌓이는 문제를 방지합니다.

2. **`.so` 파일에 누락된 `lib` 접두사 추가**:
   - `.so` 공유 라이브러리 파일 이름에 `lib` 접두사가 누락된 문제를 수정했습니다.
   - 표준 규칙에 따라 공유 라이브러리 파일 이름이 올바르게 설정되도록 보장합니다.

3. **공유 라이브러리 빌드 오류 수정**:
   - 공유 라이브러리(`.so`)와 관련된 빌드 오류를 해결했습니다.
   - 필요한 `Makefile` 규칙을 업데이트하여 컴파일 및 링킹 오류가 발생하지 않도록 수정했습니다.

### 관련 이슈:
- Closes #38: `Makefile`에서 생성된 파일 정리.
- Closes #43: 공유 라이브러리 파일명에 `lib` 접두사 누락 수정.
- 공유 라이브러리 빌드 오류에 대한 추가 수정.

### 테스트 단계:
- `make` 명령어를 실행하여 `.so` 파일이 올바르게 이름이 지정되었는지 확인합니다(e.g., `lib` 접두사가 포함된 파일).
- 공유 라이브러리가 오류 없이 컴파일되는지 확인합니다.
- 생성된 파일이 빌드 디렉토리에 적절히 정리되었는지 확인합니다.

### 참고:
- 이번 수정은 공유 라이브러리 빌드의 유지보수성과 표준 준수성을 개선합니다.